### PR TITLE
Feature/#22472 Replace title/description generation with redborder-agents instead of rb-llm

### DIFF
--- a/resources/ohai/plugins/redborder.rb
+++ b/resources/ohai/plugins/redborder.rb
@@ -95,7 +95,7 @@ Ohai.plugin(:Redborder) do
       services = ["chef-client", "consul", "zookeeper", "kafka", "webui", "rb-workers", "redborder-monitor", "druid-coordinator",
                   "druid-router","druid-indexer", "rb-druid-indexer", "druid-middlemanager", "druid-overlord", "druid-historical", "druid-broker", "opscode-erchef", "postgresql", "nginx", "memcached", "n2klocd", "redborder-nmsp", "redis",
                   "opscode-bookshelf", "opscode-chef-mover", "opscode-rabbitmq", "http2k", "redborder-cep", "snmpd", "snmptrapd",
-                  "redborder-dswatcher", "redborder-events-counter", "sfacctd", "redborder-ale", "logstash", "mongod", "minio", "redborder-llm"]
+                  "redborder-dswatcher", "redborder-events-counter", "sfacctd", "redborder-ale", "logstash", "mongod", "minio"]
       services.each do |s|
         service_data = Mash.new
         service_data[:name] = s


### PR DESCRIPTION
## Related issue in RedMine

- [Associated Redmine task](https://redmine.redborder.lan/issues/22472)

## Description

Remove **redborder-llm** from the list of services in Redborder Ohai plugin.